### PR TITLE
[camino-tempfile] add new APIs, deprecate some, mirroring upstream

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -421,9 +421,9 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.19.1"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7437ac7763b9b123ccf33c338a5cc1bac6f69b45a136c19bdd8a65e3916435bf"
+checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
 dependencies = [
  "fastrand",
  "getrandom",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ globwalk = "0.9.1"
 predicates = "3.1.0"
 predicates-core = "1.0.6"
 predicates-tree = "1.0.12"
-tempfile = "3.8.1"
+tempfile = "3.20.0"
 
 [workspace.lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(doc_cfg)'] }

--- a/crates/camino-tempfile/CHANGELOG.md
+++ b/crates/camino-tempfile/CHANGELOG.md
@@ -3,6 +3,15 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.0] - 2025-05-11
+
+### Added
+
+Updates corresponding to upstream `tempfile`:
+
+- `Builder::disable_cleanup`, `Utf8TempDir::disable_cleanup`, `NamedUtf8TempFile::disable_cleanup`, and `Utf8TempPath::disable_cleanup` conditionally disable cleanup for temporary files and directories.
+- `Builder::permissions` sets permissions for temporary files and directories.
+
 ## [1.3.0] - 2025-05-03
 
 ### Added
@@ -56,6 +65,7 @@ Fix a publishing issue.
 
 Initial release.
 
+[1.4.0]: https://github.com/camino-rs/camino-tempfile/releases/tag/camino-tempfile-1.4.0
 [1.3.0]: https://github.com/camino-rs/camino-tempfile/releases/tag/camino-tempfile-1.3.0
 [1.2.0]: https://github.com/camino-rs/camino-tempfile/releases/tag/camino-tempfile-1.2.0
 [1.1.1]: https://github.com/camino-rs/camino-tempfile/releases/tag/camino-tempfile-1.1.1

--- a/crates/camino-tempfile/src/dir.rs
+++ b/crates/camino-tempfile/src/dir.rs
@@ -383,6 +383,13 @@ impl Utf8TempDir {
         self.as_ref()
     }
 
+    /// Deprecated alias for [`Utf8TempDir::keep`].
+    #[must_use]
+    #[deprecated(since = "1.4.0", note = "use Utf8TempDir::keep")]
+    pub fn into_path(self) -> Utf8PathBuf {
+        self.keep()
+    }
+
     /// Persist the temporary directory to disk, returning the [`Utf8PathBuf`] where it is located.
     ///
     /// This consumes the [`Utf8TempDir`] without deleting directory on the filesystem, meaning that
@@ -400,7 +407,7 @@ impl Utf8TempDir {
     ///
     /// // Persist the temporary directory to disk,
     /// // getting the path where it is.
-    /// let tmp_path = tmp_dir.into_path();
+    /// let tmp_path = tmp_dir.keep();
     ///
     /// // Delete the temporary directory ourselves.
     /// fs::remove_dir_all(tmp_path)?;
@@ -408,11 +415,23 @@ impl Utf8TempDir {
     /// # }
     /// ```
     #[must_use]
-    pub fn into_path(self) -> Utf8PathBuf {
+    pub fn keep(self) -> Utf8PathBuf {
         self.inner
-            .into_path()
+            .keep()
             .try_into()
             .expect("invariant: path is valid UTF-8")
+    }
+
+    /// Disable cleanup of the temporary directory. If `disable_cleanup` is
+    /// `true`, the temporary directory will not be deleted when this
+    /// `Utf8TempDir` is dropped. This method is equivalent to calling
+    /// [`Builder::disable_cleanup`] when creating the `Utf8TempDir`.
+    ///
+    /// **NOTE:** this method is primarily useful for testing/debugging. If you
+    /// want to simply turn a temporary directory into a non-temporary
+    /// directory, prefer [`TUtf8empDir::keep`].
+    pub fn disable_cleanup(&mut self, disable_cleanup: bool) {
+        self.inner.disable_cleanup(disable_cleanup);
     }
 
     /// Closes and removes the temporary directory, returning a `Result`.

--- a/crates/camino-tempfile/src/file.rs
+++ b/crates/camino-tempfile/src/file.rs
@@ -347,6 +347,19 @@ impl Utf8TempPath {
         }
     }
 
+    /// Disable cleanup of the temporary file. If `disable_cleanup` is `true`,
+    /// the temporary file will not be deleted when this `Utf8TempPath` is
+    /// dropped. This method is equivalent to calling
+    /// [`Builder::disable_cleanup`] when creating the original `Utf8TempPath`,
+    /// which see for relevant warnings.
+    ///
+    /// **NOTE:** this method is primarily useful for testing/debugging. If you
+    /// want to simply turn a temporary file-path into a non-temporary
+    /// file-path, prefer [`Utf8TempPath::keep`].
+    pub fn disable_cleanup(&mut self, disable_cleanup: bool) {
+        self.inner.disable_cleanup(disable_cleanup);
+    }
+
     /// Create a new `Utf8TempPath` from an existing path. This can be done even if no file exists
     /// at the given path.
     ///
@@ -852,6 +865,19 @@ impl<F> NamedUtf8TempFile<F> {
                 error: error.error,
             }),
         }
+    }
+
+    /// Disable cleanup of the temporary file. If `disable_cleanup` is `true`,
+    /// the temporary file will not be deleted when this `NamedUtf8TempFile` is
+    /// dropped. This method is equivalent to calling
+    /// [`Builder::disable_cleanup`] when creating the original
+    /// `NamedUtf8TempFile`, which see for relevant warnings.
+    ///
+    /// **NOTE:** this method is primarily useful for testing/debugging. If you
+    /// want to simply turn a temporary file into a non-temporary file, prefer
+    /// [`NamedUtf8TempFile::keep`].
+    pub fn disable_cleanup(&mut self, disable_cleanup: bool) {
+        self.inner.disable_cleanup(disable_cleanup);
     }
 
     /// Get a reference to the underlying file.

--- a/crates/camino-tempfile/tests/namedtempfile.rs
+++ b/crates/camino-tempfile/tests/namedtempfile.rs
@@ -388,40 +388,6 @@ fn test_make_uds() {
     assert!(temp_sock.path().exists());
 }
 
-#[cfg(unix)]
-#[test]
-fn test_make_uds_conflict() {
-    use std::{io::ErrorKind, os::unix::net::UnixListener};
-
-    let sockets = std::iter::repeat_with(|| {
-        Builder::new()
-            .prefix("tmp")
-            .suffix(".sock")
-            .rand_bytes(1)
-            .make(|path| UnixListener::bind(path))
-    })
-    .take_while(|r| match r {
-        Ok(_) => true,
-        Err(e) if matches!(e.kind(), ErrorKind::AddrInUse | ErrorKind::AlreadyExists) => false,
-        Err(e) => panic!("unexpected error {e}"),
-    })
-    .collect::<Result<Vec<_>, _>>()
-    .unwrap();
-
-    // Number of sockets we can create. Depends on whether or not the filesystem is case sensitive.
-
-    #[cfg(target_os = "macos")]
-    const NUM_FILES: usize = 36;
-    #[cfg(not(target_os = "macos"))]
-    const NUM_FILES: usize = 62;
-
-    assert_eq!(sockets.len(), NUM_FILES);
-
-    for socket in sockets {
-        assert!(socket.path().exists());
-    }
-}
-
 // Issue #224 on tempfile-rs.
 #[test]
 fn test_overly_generic_bounds() {

--- a/crates/camino-tempfile/tests/tempdir.rs
+++ b/crates/camino-tempfile/tests/tempdir.rs
@@ -82,7 +82,7 @@ fn test_rm_tempdir() {
     let path;
     {
         let tmp = t!(Utf8TempDir::new());
-        path = tmp.into_path();
+        path = tmp.keep();
     }
     assert!(path.exists());
     t!(fs::remove_dir_all(&path));
@@ -125,7 +125,7 @@ fn test_rm_tempdir_close() {
     let path;
     {
         let tmp = t!(Utf8TempDir::new());
-        path = tmp.into_path();
+        path = tmp.keep();
     }
     assert!(path.exists());
     t!(fs::remove_dir_all(&path));


### PR DESCRIPTION
Add:

* `Utf8TempDir::keep`
* `disable_cleanup` methods
* `Builder::permissions`

Deprecate `Utf8TempDir::into_path` to match upstream.