### PR TITLE
[camino-tempfile-ext] improvements to FixtureError

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,5 @@
 [alias]
-xfmt = "fmt --all -- --config imports_granularity=Crate --config group_imports=One"
+xfmt = "fmt --all -- --config imports_granularity=Crate --config group_imports=One --config format_code_in_doc_comments=true"
 
 [resolver]
 incompatible-rust-versions = "fallback"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,6 +62,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.98"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
+
+[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -104,6 +110,7 @@ version = "0.3.0"
 dependencies = [
  "anstream",
  "anstyle",
+ "anyhow",
  "camino",
  "camino-tempfile",
  "globwalk",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ rust-version = "1.74"
 [workspace.dependencies]
 anstream = "0.6.18"
 anstyle = "1.0.10"
+anyhow = "1.0.98"
 camino = "1.1.4"
 camino-tempfile = { path = "crates/camino-tempfile", version = "1.4.1" }
 fastrand = "2.0.1"

--- a/crates/camino-tempfile-ext/Cargo.toml
+++ b/crates/camino-tempfile-ext/Cargo.toml
@@ -23,6 +23,9 @@ predicates = { workspace = true, optional = true }
 predicates-core = { workspace = true, optional = true }
 predicates-tree = { workspace = true, optional = true }
 
+[dev-dependencies]
+anyhow.workspace = true
+
 [features]
 assert = ["dep:predicates", "dep:predicates-core", "dep:predicates-tree"]
 assert-color = ["assert", "dep:anstream", "dep:anstyle", "predicates/color"]

--- a/crates/camino-tempfile-ext/src/fixture/tools.rs
+++ b/crates/camino-tempfile-ext/src/fixture/tools.rs
@@ -22,7 +22,6 @@ pub trait PathCreateDir {
     /// temp.child("subdir").create_dir_all().unwrap();
     /// temp.close().unwrap();
     /// ```
-    ///
     fn create_dir_all(&self) -> Result<(), FixtureError>;
 }
 
@@ -33,7 +32,6 @@ impl PathCreateDir for ChildPath {
 }
 
 /// Create empty files at [`ChildPath`].
-///
 pub trait FileTouch {
     /// Create an empty file at [`ChildPath`].
     ///
@@ -46,7 +44,6 @@ pub trait FileTouch {
     /// temp.child("foo.txt").touch().unwrap();
     /// temp.close().unwrap();
     /// ```
-    ///
     fn touch(&self) -> Result<(), FixtureError>;
 }
 
@@ -63,7 +60,6 @@ impl FileTouch for NamedUtf8TempFile {
 }
 
 /// Write a binary file at [`ChildPath`].
-///
 pub trait FileWriteBin {
     /// Write a binary file at [`ChildPath`].
     ///
@@ -73,13 +69,11 @@ pub trait FileWriteBin {
     /// use camino_tempfile_ext::prelude::*;
     ///
     /// let temp = Utf8TempDir::new().unwrap();
-    /// temp
-    ///     .child("foo.txt")
+    /// temp.child("foo.txt")
     ///     .write_binary(b"To be or not to be...")
     ///     .unwrap();
     /// temp.close().unwrap();
     /// ```
-    ///
     fn write_binary(&self, data: &[u8]) -> Result<(), FixtureError>;
 }
 
@@ -105,10 +99,9 @@ pub trait FileWriteStr {
     /// use camino_tempfile_ext::prelude::*;
     ///
     /// let temp = Utf8TempDir::new().unwrap();
-    /// temp
-    ///    .child("foo.txt")
-    ///    .write_str("To be or not to be...")
-    ///    .unwrap();
+    /// temp.child("foo.txt")
+    ///     .write_str("To be or not to be...")
+    ///     .unwrap();
     /// temp.close().unwrap();
     /// ```
     fn write_str(&self, data: &str) -> Result<(), FixtureError>;
@@ -137,13 +130,11 @@ pub trait FileWriteFile {
     /// use camino_tempfile_ext::prelude::*;
     ///
     /// let temp = Utf8TempDir::new().unwrap();
-    /// temp
-    ///    .child("foo.txt")
-    ///    .write_file(Utf8Path::new("Cargo.toml"))
-    ///    .unwrap();
+    /// temp.child("foo.txt")
+    ///     .write_file(Utf8Path::new("Cargo.toml"))
+    ///     .unwrap();
     /// temp.close().unwrap();
     /// ```
-    ///
     fn write_file(&self, data: &Utf8Path) -> Result<(), FixtureError>;
 }
 
@@ -201,7 +192,6 @@ impl PathCopy for ChildPath {
 }
 
 /// Create a symlink to a target file.
-///
 pub trait SymlinkToFile {
     /// Create a symlink to the provided target file.
     ///
@@ -214,7 +204,9 @@ pub trait SymlinkToFile {
     /// let real_file = temp.child("real_file");
     /// real_file.touch().unwrap();
     ///
-    /// temp.child("link_file").symlink_to_file(real_file.as_path()).unwrap();
+    /// temp.child("link_file")
+    ///     .symlink_to_file(real_file.as_path())
+    ///     .unwrap();
     ///
     /// temp.close().unwrap();
     /// ```
@@ -246,7 +238,9 @@ pub trait SymlinkToDir {
     /// let real_dir = temp.child("real_dir");
     /// real_dir.create_dir_all().unwrap();
     ///
-    /// temp.child("link_dir").symlink_to_dir(real_dir.as_path()).unwrap();
+    /// temp.child("link_dir")
+    ///     .symlink_to_dir(real_dir.as_path())
+    ///     .unwrap();
     ///
     /// temp.close().unwrap();
     /// ```

--- a/crates/camino-tempfile/src/builder.rs
+++ b/crates/camino-tempfile/src/builder.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The camino-tempfile Contributors
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use crate::{helpers::utf8_env_temp_dir, NamedUtf8TempFile, Utf8TempDir};
+use crate::{NamedUtf8TempFile, Utf8TempDir, helpers::utf8_env_temp_dir};
 use camino::{Utf8Path, Utf8PathBuf};
 use std::{convert::TryFrom, io};
 

--- a/crates/camino-tempfile/src/builder.rs
+++ b/crates/camino-tempfile/src/builder.rs
@@ -108,9 +108,7 @@ impl<'a, 'b> Builder<'a, 'b> {
     /// # }
     /// # fn run() -> Result<(), io::Error> {
     /// # use camino_tempfile::Builder;
-    /// let named_tempfile = Builder::new()
-    ///     .prefix("my-temporary-note")
-    ///     .tempfile()?;
+    /// let named_tempfile = Builder::new().prefix("my-temporary-note").tempfile()?;
     /// # Ok(())
     /// # }
     /// ```
@@ -135,9 +133,7 @@ impl<'a, 'b> Builder<'a, 'b> {
     /// # }
     /// # fn run() -> Result<(), io::Error> {
     /// # use camino_tempfile::Builder;
-    /// let named_tempfile = Builder::new()
-    ///     .suffix(".txt")
-    ///     .tempfile()?;
+    /// let named_tempfile = Builder::new().suffix(".txt").tempfile()?;
     /// # Ok(())
     /// # }
     /// ```
@@ -161,9 +157,7 @@ impl<'a, 'b> Builder<'a, 'b> {
     /// # }
     /// # fn run() -> Result<(), io::Error> {
     /// # use camino_tempfile::Builder;
-    /// let named_tempfile = Builder::new()
-    ///     .rand_bytes(5)
-    ///     .tempfile()?;
+    /// let named_tempfile = Builder::new().rand_bytes(5).tempfile()?;
     /// # Ok(())
     /// # }
     /// ```
@@ -187,9 +181,7 @@ impl<'a, 'b> Builder<'a, 'b> {
     /// # }
     /// # fn run() -> Result<(), io::Error> {
     /// # use camino_tempfile::Builder;
-    /// let named_tempfile = Builder::new()
-    ///     .append(true)
-    ///     .tempfile()?;
+    /// let named_tempfile = Builder::new().append(true).tempfile()?;
     /// # Ok(())
     /// # }
     /// ```
@@ -295,9 +287,7 @@ impl<'a, 'b> Builder<'a, 'b> {
     /// ```
     /// use camino_tempfile::Builder;
     ///
-    /// let named_tempfile = Builder::new()
-    ///     .disable_cleanup(true)
-    ///     .tempfile()?;
+    /// let named_tempfile = Builder::new().disable_cleanup(true).tempfile()?;
     /// # Ok::<(), std::io::Error>(())
     /// ```
     pub fn disable_cleanup(&mut self, disable_cleanup: bool) -> &mut Self {
@@ -394,9 +384,8 @@ impl<'a, 'b> Builder<'a, 'b> {
     /// # Examples
     ///
     /// ```
-    /// use std::fs::File;
-    /// use std::io::Write;
     /// use camino_tempfile::Builder;
+    /// use std::{fs::File, io::Write};
     ///
     /// # use std::io;
     /// # fn run() -> Result<(), io::Error> {
@@ -425,9 +414,11 @@ impl<'a, 'b> Builder<'a, 'b> {
     /// # Examples
     ///
     /// ```
-    /// use std::fs::{self, File};
-    /// use std::io::Write;
     /// use camino_tempfile::Builder;
+    /// use std::{
+    ///     fs::{self, File},
+    ///     io::Write,
+    /// };
     ///
     /// # use std::io;
     /// # fn run() -> Result<(), io::Error> {

--- a/crates/camino-tempfile/src/dir.rs
+++ b/crates/camino-tempfile/src/dir.rs
@@ -27,8 +27,10 @@ use tempfile::TempDir;
 ///
 /// ```
 /// use camino_tempfile::tempdir;
-/// use std::fs::File;
-/// use std::io::{self, Write};
+/// use std::{
+///     fs::File,
+///     io::{self, Write},
+/// };
 ///
 /// # fn main() {
 /// #     if let Err(_) = run() {
@@ -74,8 +76,10 @@ pub fn tempdir() -> io::Result<Utf8TempDir> {
 ///
 /// ```
 /// use camino_tempfile::tempdir_in;
-/// use std::fs::File;
-/// use std::io::{self, Write};
+/// use std::{
+///     fs::File,
+///     io::{self, Write},
+/// };
 ///
 /// # fn main() {
 /// #     if let Err(_) = run() {
@@ -136,9 +140,8 @@ pub fn tempdir_in<P: AsRef<Utf8Path>>(dir: P) -> io::Result<Utf8TempDir> {
 /// Create a temporary directory with a generated name:
 ///
 /// ```
-/// use std::fs::File;
-/// use std::io::Write;
 /// use camino_tempfile::Utf8TempDir;
+/// use std::{fs::File, io::Write};
 ///
 /// # use std::io;
 /// # fn run() -> Result<(), io::Error> {
@@ -151,9 +154,8 @@ pub fn tempdir_in<P: AsRef<Utf8Path>>(dir: P) -> io::Result<Utf8TempDir> {
 /// Create a temporary directory with a prefix in its name:
 ///
 /// ```
-/// use std::fs::File;
-/// use std::io::Write;
 /// use camino_tempfile::Builder;
+/// use std::{fs::File, io::Write};
 ///
 /// # use std::io;
 /// # fn run() -> Result<(), io::Error> {
@@ -190,9 +192,8 @@ impl Utf8TempDir {
     /// # Examples
     ///
     /// ```
-    /// use std::fs::File;
-    /// use std::io::Write;
     /// use camino_tempfile::Utf8TempDir;
+    /// use std::{fs::File, io::Write};
     ///
     /// # use std::io;
     /// # fn run() -> Result<(), io::Error> {
@@ -222,9 +223,11 @@ impl Utf8TempDir {
     /// # Examples
     ///
     /// ```
-    /// use std::fs::{self, File};
-    /// use std::io::Write;
     /// use camino_tempfile::Utf8TempDir;
+    /// use std::{
+    ///     fs::{self, File},
+    ///     io::Write,
+    /// };
     ///
     /// # use std::io;
     /// # fn run() -> Result<(), io::Error> {
@@ -251,9 +254,11 @@ impl Utf8TempDir {
     /// # Examples
     ///
     /// ```
-    /// use std::fs::{self, File};
-    /// use std::io::Write;
     /// use camino_tempfile::Utf8TempDir;
+    /// use std::{
+    ///     fs::{self, File},
+    ///     io::Write,
+    /// };
     ///
     /// # use std::io;
     /// # fn run() -> Result<(), io::Error> {
@@ -279,9 +284,11 @@ impl Utf8TempDir {
     /// # Examples
     ///
     /// ```
-    /// use std::fs::{self, File};
-    /// use std::io::Write;
     /// use camino_tempfile::Utf8TempDir;
+    /// use std::{
+    ///     fs::{self, File},
+    ///     io::Write,
+    /// };
     ///
     /// # use std::io;
     /// # fn run() -> Result<(), io::Error> {
@@ -310,9 +317,11 @@ impl Utf8TempDir {
     /// # Examples
     ///
     /// ```
-    /// use std::fs::{self, File};
-    /// use std::io::Write;
     /// use camino_tempfile::Utf8TempDir;
+    /// use std::{
+    ///     fs::{self, File},
+    ///     io::Write,
+    /// };
     ///
     /// // Create a directory inside of the current directory
     /// let tmp_dir = Utf8TempDir::with_suffix("-foo")?;
@@ -335,9 +344,11 @@ impl Utf8TempDir {
     /// # Examples
     ///
     /// ```
-    /// use std::fs::{self, File};
-    /// use std::io::Write;
     /// use camino_tempfile::Utf8TempDir;
+    /// use std::{
+    ///     fs::{self, File},
+    ///     io::Write,
+    /// };
     ///
     /// // Create a directory inside of the current directory
     /// let tmp_dir = Utf8TempDir::with_suffix_in("-foo", ".")?;
@@ -364,13 +375,13 @@ impl Utf8TempDir {
     /// let tmp_path;
     ///
     /// {
-    ///    let tmp_dir = Utf8TempDir::new()?;
-    ///    tmp_path = tmp_dir.path().to_owned();
+    ///     let tmp_dir = Utf8TempDir::new()?;
+    ///     tmp_path = tmp_dir.path().to_owned();
     ///
-    ///    // Check that the temp directory actually exists.
-    ///    assert!(tmp_path.exists());
+    ///     // Check that the temp directory actually exists.
+    ///     assert!(tmp_path.exists());
     ///
-    ///    // End of `tmp_dir` scope, directory will be deleted
+    ///     // End of `tmp_dir` scope, directory will be deleted
     /// }
     ///
     /// // Temp directory should be deleted by now
@@ -398,8 +409,8 @@ impl Utf8TempDir {
     /// # Examples
     ///
     /// ```
-    /// use std::fs;
     /// use camino_tempfile::Utf8TempDir;
+    /// use std::fs;
     ///
     /// # use std::io;
     /// # fn run() -> Result<(), io::Error> {
@@ -448,9 +459,8 @@ impl Utf8TempDir {
     /// # Examples
     ///
     /// ```
-    /// use std::fs::File;
-    /// use std::io::Write;
     /// use camino_tempfile::Utf8TempDir;
+    /// use std::{fs::File, io::Write};
     ///
     /// # use std::io;
     /// # fn run() -> Result<(), io::Error> {

--- a/crates/camino-tempfile/src/file.rs
+++ b/crates/camino-tempfile/src/file.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The camino-tempfile Contributors
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use crate::{errors::IoResultExt, Builder};
+use crate::{Builder, errors::IoResultExt};
 use camino::{Utf8Path, Utf8PathBuf};
 use std::{
     convert::{TryFrom, TryInto},

--- a/crates/camino-tempfile/src/lib.rs
+++ b/crates/camino-tempfile/src/lib.rs
@@ -73,7 +73,10 @@
 //!
 //! // Spawn the `touch` command inside the temporary directory and collect the exit status
 //! // Note that `temp_dir` is **not** moved into `current_dir`, but passed as a reference
-//! let exit_status = Command::new("touch").arg("tmp").current_dir(&temp_dir).status()?;
+//! let exit_status = Command::new("touch")
+//!     .arg("tmp")
+//!     .current_dir(&temp_dir)
+//!     .status()?;
 //! assert!(exit_status.success());
 //!
 //! # Ok(())
@@ -114,7 +117,7 @@
 //!
 //! ```
 //! use camino_tempfile::NamedUtf8TempFile;
-//! use std::io::{self, Write, Read};
+//! use std::io::{self, Read, Write};
 //!
 //! # fn main() {
 //! #     if let Err(_) = run() {
@@ -145,8 +148,10 @@
 //!
 //! ```
 //! use camino_tempfile::tempdir;
-//! use std::fs::File;
-//! use std::io::{self, Write};
+//! use std::{
+//!     fs::File,
+//!     io::{self, Write},
+//! };
 //!
 //! # fn main() {
 //! #     if let Err(_) = run() {

--- a/crates/camino-tempfile/tests/namedtempfile.rs
+++ b/crates/camino-tempfile/tests/namedtempfile.rs
@@ -1,7 +1,7 @@
 #![deny(rust_2018_idioms)]
 
 use camino::{Utf8Path, Utf8PathBuf};
-use camino_tempfile::{tempdir, Builder, NamedUtf8TempFile, Utf8TempPath};
+use camino_tempfile::{Builder, NamedUtf8TempFile, Utf8TempPath, tempdir};
 use std::{
     env,
     fs::File,

--- a/crates/camino-tempfile/tests/tempfile.rs
+++ b/crates/camino-tempfile/tests/tempfile.rs
@@ -6,7 +6,7 @@ use std::{
 };
 #[cfg(target_os = "linux")]
 use std::{
-    sync::mpsc::{sync_channel, TryRecvError},
+    sync::mpsc::{TryRecvError, sync_channel},
     thread,
 };
 

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,2 @@
+edition = "2021"
+style_edition = "2024"


### PR DESCRIPTION
Allow attaching a source to the error externally, and make Display formatting follow modern Rust conventions.